### PR TITLE
Fix pod spec v3 changes to serviceAccount

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -62,25 +62,27 @@ class MultusCharm(CharmBase):
                 }
             }],
             'serviceAccount': {
-                'global': True,
-                'rules': [
-                    {
-                        'apiGroups': ['k8s.cni.cncf.io'],
-                        'resources': ['*'],
-                        'verbs': ['*']
-                    },
-                    {
-                        'apiGroups': [''],
-                        'resources': [
-                            'pods',
-                            'pods/status'
-                        ],
-                        'verbs': [
-                            'get',
-                            'update'
-                        ]
-                    }
-                ]
+                'roles': [{
+                    'global': True,
+                    'rules': [
+                        {
+                            'apiGroups': ['k8s.cni.cncf.io'],
+                            'resources': ['*'],
+                            'verbs': ['*']
+                        },
+                        {
+                            'apiGroups': [''],
+                            'resources': [
+                                'pods',
+                                'pods/status'
+                            ],
+                            'verbs': [
+                                'get',
+                                'update'
+                            ]
+                        }
+                    ]
+                }]
             },
             'kubernetesResources': {
                 'pod': {


### PR DESCRIPTION
https://bugs.launchpad.net/charm-multus/+bug/1862020

The multus charm currently raises a hook error during install, due to a change in Juju's pod spec v3 API ([upstream PR](https://github.com/juju/juju/pull/11293)). The serviceAccount field, instead of implicitly assuming there is only one role, now requires roles to be specified in a list.

This PR fixes the hook error by updating our pod spec to conform to those changes.