### PR TITLE
Fix pod spec for CRD change in Juju 2.8

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -19,3 +19,4 @@ resources:
 deployment:
   type: daemon
   service: omit
+min-juju-version: 2.8-beta1

--- a/src/charm.py
+++ b/src/charm.py
@@ -88,8 +88,9 @@ class MultusCharm(CharmBase):
                 'pod': {
                     'hostNetwork': True
                 },
-                'customResourceDefinitions': {
-                    'network-attachment-definitions.k8s.cni.cncf.io': {
+                'customResourceDefinitions': [{
+                    'name': 'network-attachment-definitions.k8s.cni.cncf.io',
+                    'spec': {
                         'group': 'k8s.cni.cncf.io',
                         'scope': 'Namespaced',
                         'names': {
@@ -119,7 +120,7 @@ class MultusCharm(CharmBase):
                             }
                         }
                     }
-                }
+                }]
             }
         })
 


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-multus/+bug/1862020

The Multus charm is currently hitting this hook error during install:

```
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm Traceback (most recent call last):
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm   File "lib/ops/model.py", line 626, in _run
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm     result = run(args, check=True, **kwargs)
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm   File "/usr/lib/python3.6/subprocess.py", line 438, in run
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm     output=stdout, stderr=stderr)
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm subprocess.CalledProcessError: Command '('pod-spec-set', '--file', '/tmp/tmpnpsonnjs-pod-spec-set/spec.json')' returned non-zero exit status 1.
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm During handling of the above exception, another exception occurred:
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm Traceback (most recent call last):
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm   File "/var/lib/juju/agents/unit-multus-0/charm/hooks/upgrade-charm", line 130, in <module>
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm     main(MultusCharm)
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm   File "lib/ops/main.py", line 191, in main
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm     _emit_charm_event(charm, juju_event_name)
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm   File "lib/ops/main.py", line 120, in _emit_charm_event
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm     event_to_emit.emit(*args, **kwargs)
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm   File "lib/ops/framework.py", line 192, in emit
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm     framework._emit(event)
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm   File "lib/ops/framework.py", line 602, in _emit
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm     self._reemit(event_path)
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm   File "lib/ops/framework.py", line 637, in _reemit
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm     custom_handler(event)
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm   File "/var/lib/juju/agents/unit-multus-0/charm/hooks/upgrade-charm", line 114, in set_pod_spec
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm     'type': 'string'
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm   File "lib/ops/model.py", line 533, in set_spec
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm     self._backend.pod_spec_set(spec, k8s_resources)
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm   File "lib/ops/model.py", line 704, in pod_spec_set
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm     self._run('pod-spec-set', *args)
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm   File "lib/ops/model.py", line 628, in _run
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm     raise ModelError(e.stderr)
application-multus: 16:11:21 DEBUG unit.multus/0.upgrade-charm ops.model.ModelError: b'2020-03-20 21:11:21 WARNING juju.juju.series supportedseries.go:692 failed to update distro info: open /usr/share/distro-info/ubuntu.csv: no such file or directory\nERROR json: cannot unmarshal object into Go struct field KubernetesResources.customResourceDefinitions of type []specs.K8sCustomResourceDefinitionSpec\n'
application-multus: 16:11:21 ERROR juju.worker.uniter.operation hook "upgrade-charm" (via explicit, bespoke hook script) failed: exit status 1
```

It appears the pod spec v3 schema was changed again: https://github.com/juju/juju/pull/11315

This PR updates the Multus charm to use the new pod spec v3 schema for customResourceDefinitions.