### PR TITLE
Multus images with Ubuntu and Debug option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,25 @@ This is a charm for running Multus CNI on Charmed Kubernetes.
 This charm is maintained along with the components of Charmed Kubernetes. For
 full information, please visit the
 [official Charmed Kubernetes docs](https://ubuntu.com/kubernetes/docs/cni-multus).
+
+## Build
+
+Docker is needed to build the images and push it to the charmstore. Suggested:
+
+$ sudo snap install docker --classic
+
+Follow steps on docker documenation to enable it for your current user.
+
+Install dependencies to start running this deployment:
+
+$ make bootstrap
+
+You can build the charm with:
+
+$ make charm
+
+That will build the multus.charm file and all container images will be on docker. 
+Push the charm with the images to the charmstore.
+
+$ export NAMESPACE=<namespace-to-be-used-on-charmstore>
+$ make upload

--- a/README.md
+++ b/README.md
@@ -26,4 +26,9 @@ That will build the multus.charm file and all container images will be on docker
 Push the charm with the images to the charmstore.
 
 $ export NAMESPACE=<namespace-to-be-used-on-charmstore>
+$ export CHANNEL=<as defined on: https://discourse.charmhub.io/t/the-juju-charm-store/1045>
 $ make upload
+
+Once the upload is finished, give access to your charm with:
+
+$ charm grant <charm-url> <users or anyone keyword>

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,12 @@
 options:
+  debug:
+    type: boolean
+    default: False
+    description: |
+      Set it to enable LogLevel=debug and reload debug image for containers.
+      Access kube-multus for debug with:
+      kubectl exec -n <model-name> -it <pod-name> -- bash
+      $ dlv attach --continue <PID>
   network-attachment-definitions:
     type: string
     default: ''

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,9 @@ resources:
   multus-image:
     type: oci-image
     description: 'Multus image'
-    upstream-source: nfvpe/multus:v3.4
+  multus-debug-image:
+    type: oci-image
+    description: 'Multus image with debug info'
   net-attach-def-manager-image:
     type: oci-image
     description: 'net-attach-def-manager image'

--- a/multus-debug/Dockerfile
+++ b/multus-debug/Dockerfile
@@ -5,10 +5,12 @@ FROM ubuntu:20.04 as build
 ENV DEBIAN_FRONTEND "noninteractive"
 RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
 
-ENV INSTALL_PKGS "git golang-1.13"
+ENV INSTALL_PKGS "git golang-1.13 python3 python3-yaml"
+
 RUN apt update && \
     apt install -y $INSTALL_PKGS && \
     ln -s /usr/lib/go-1.13/bin/go /usr/bin/go && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
     git clone https://github.com/k8snetworkplumbingwg/multus-cni /usr/src/multus-cni && \
     cd /usr/src/multus-cni && \
     ./hack/build-go.sh
@@ -17,14 +19,20 @@ RUN apt update && \
 ENV GO111MODULE "on"
 RUN git clone https://github.com/go-delve/delve && \
     cd delve && \
-    go build ./cmd/dlv
-
+    go build ./cmd/dlv && \
+    mv dlv /usr/bin
 
 # Actual container
 FROM ubuntu:20.04
 
-LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
+ENV INSTALL_PKGS "python3 python3-yaml"
+
+RUN apt update && \
+    apt install -y $INSTALL_PKGS && \
+    ln -s /usr/bin/python3 /usr/bin/python
+
 COPY --from=build /usr/src/multus-cni /usr/src/multus-cni
+COPY --from=build /usr/bin/dlv /usr/bin/dlv
 WORKDIR /
 
 RUN cp /usr/src/multus-cni/images/entrypoint.sh /

--- a/multus-debug/Dockerfile
+++ b/multus-debug/Dockerfile
@@ -1,0 +1,31 @@
+# This Dockerfile is used to build the image available on DockerHub
+FROM ubuntu:20.04 as build
+
+# Avoid asking for TZ info
+ENV DEBIAN_FRONTEND "noninteractive"
+RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+
+ENV INSTALL_PKGS "git golang-1.13"
+RUN apt update && \
+    apt install -y $INSTALL_PKGS && \
+    ln -s /usr/lib/go-1.13/bin/go /usr/bin/go && \
+    git clone https://github.com/k8snetworkplumbingwg/multus-cni /usr/src/multus-cni && \
+    cd /usr/src/multus-cni && \
+    ./hack/build-go.sh
+
+# Building with go modules
+ENV GO111MODULE "on"
+RUN git clone https://github.com/go-delve/delve && \
+    cd delve && \
+    go build ./cmd/dlv
+
+
+# Actual container
+FROM ubuntu:20.04
+
+LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
+COPY --from=build /usr/src/multus-cni /usr/src/multus-cni
+WORKDIR /
+
+RUN cp /usr/src/multus-cni/images/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/multus-debug/build
+++ b/multus-debug/build
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eux
+
+DOCKER_BUILDKIT=1 docker build . -t multus-debug

--- a/multus/Dockerfile
+++ b/multus/Dockerfile
@@ -1,0 +1,25 @@
+# This Dockerfile is used to build the image available on DockerHub
+FROM ubuntu:20.04 as build
+
+ENV INSTALL_PKGS "git golang-1.13"
+
+# Avoid asking for TZ info
+ENV DEBIAN_FRONTEND "noninteractive"
+RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+
+RUN apt update && \
+    apt install -y $INSTALL_PKGS && \
+    ln -s /usr/lib/go-1.13/bin/go /usr/bin/go && \
+    git clone https://github.com/k8snetworkplumbingwg/multus-cni /usr/src/multus-cni && \
+    cd /usr/src/multus-cni && \
+    ./hack/build-go.sh
+
+# Actual container
+FROM ubuntu:20.04
+
+LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
+COPY --from=build /usr/src/multus-cni /usr/src/multus-cni
+WORKDIR /
+
+RUN cp /usr/src/multus-cni/images/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/multus/Dockerfile
+++ b/multus/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used to build the image available on DockerHub
 FROM ubuntu:20.04 as build
 
-ENV INSTALL_PKGS "git golang-1.13"
+ENV INSTALL_PKGS "git golang-1.13 python3 python3-yaml"
 
 # Avoid asking for TZ info
 ENV DEBIAN_FRONTEND "noninteractive"
@@ -10,6 +10,7 @@ RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
 RUN apt update && \
     apt install -y $INSTALL_PKGS && \
     ln -s /usr/lib/go-1.13/bin/go /usr/bin/go && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
     git clone https://github.com/k8snetworkplumbingwg/multus-cni /usr/src/multus-cni && \
     cd /usr/src/multus-cni && \
     ./hack/build-go.sh
@@ -17,7 +18,12 @@ RUN apt update && \
 # Actual container
 FROM ubuntu:20.04
 
-LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
+ENV INSTALL_PKGS "python3 python3-yaml"
+
+RUN apt update && \
+    apt install -y $INSTALL_PKGS && \
+    ln -s /usr/bin/python3 /usr/bin/python     
+
 COPY --from=build /usr/src/multus-cni /usr/src/multus-cni
 WORKDIR /
 

--- a/multus/build
+++ b/multus/build
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eux
+
+DOCKER_BUILDKIT=1 docker build . -t multus

--- a/script/build
+++ b/script/build
@@ -7,6 +7,11 @@ CHARM_SRC="$(realpath .)"
 
 echo "Building net-attach-def-manager image..."
 (cd net-attach-def-manager/; ./build)
+echo "Building net-attach-def-manager image..."
+(cd multus/; ./build)
+echo "multus-debug image..."
+(cd multus-debug/; ./build)
+
 
 echo "Building $CHARM..."
 (cd "$CHARM_BUILD_DIR" && charmcraft build -f "$CHARM_SRC" 2>&1) | sed -e "s,in ',in '$CHARM_BUILD_DIR/,"

--- a/script/upload
+++ b/script/upload
@@ -5,7 +5,9 @@ if ! charm whoami > /dev/null; then
     echo "Not logged into charm store" 2>&1
     exit 1
 fi
-URL=$(charm push "$CHARM_BUILD_DIR/$CHARM.charm" "cs:~$NAMESPACE/$CHARM" | yq r - url)
+
+
+URL=$(charm push "$CHARM_BUILD_DIR/$CHARM.charm" "cs:~$NAMESPACE/$CHARM" |  yq -r .url)
 echo "Uploaded: $URL"
 
 NADF="net-attach-def-manager"
@@ -22,6 +24,6 @@ echo "Attached: $MULTUS_DEBUG-image-$MULTUS_DEBUG_IMAGE_REV"
 
 
 if [ "$CHANNEL" != unpublished ]; then
-    charm release "$URL" --channel "$CHANNEL" --resource "$NADF-image-$NADF_IMAGE_REV" --resource "multus-image-$MULTUS_IMAGE_REV"
+    charm release "$URL" --channel "$CHANNEL" --resource "$NADF-image-$NADF_IMAGE_REV" --resource "multus-image-$MULTUS_IMAGE_REV" --resource "multus-debug-image-$MULTUS_DEBUG_IMAGE_REV"
     echo "Released to: $CHANNEL"
 fi

--- a/script/upload
+++ b/script/upload
@@ -8,14 +8,18 @@ fi
 URL=$(charm push "$CHARM_BUILD_DIR/$CHARM.charm" "cs:~$NAMESPACE/$CHARM" | yq r - url)
 echo "Uploaded: $URL"
 
-MULTUS_IMAGE=$(yq r "metadata.yaml" "resources.multus-image.upstream-source")
-docker pull "$MULTUS_IMAGE"
-MULTUS_IMAGE_REV=$(charm attach cs:~"$NAMESPACE"/"$CHARM" --channel unpublished "multus-image=$MULTUS_IMAGE" | tail -n1 | sed -e 's/uploaded revision \([0-9]*\) of.*/\1/')
-echo "Attached: multus-image-$MULTUS_IMAGE_REV"
-
 NADF="net-attach-def-manager"
 NADF_IMAGE_REV=$(charm attach cs:~"$NAMESPACE"/"$CHARM" --channel unpublished "$NADF-image=$NADF" | tail -n1 | sed -e 's/uploaded revision \([0-9]*\) of.*/\1/')
 echo "Attached: $NADF-image-$NADF_IMAGE_REV"
+
+MULTUS="multus"
+MULTUS_IMAGE_REV=$(charm attach cs:~"$NAMESPACE"/"$CHARM" --channel unpublished "$MULTUS-image=$MULTUS" | tail -n1 | sed -e 's/uploaded revision \([0-9]*\) of.*/\1/')
+echo "Attached: $MULTUS-image-$MULTUS_IMAGE_REV"
+
+MULTUS_DEBUG="multus-debug"
+MULTUS_DEBUG_IMAGE_REV=$(charm attach cs:~"$NAMESPACE"/"$CHARM" --channel unpublished "$MULTUS_DEBUG-image=$MULTUS_DEBUG" | tail -n1 | sed -e 's/uploaded revision \([0-9]*\) of.*/\1/')
+echo "Attached: $MULTUS_DEBUG-image-$MULTUS_DEBUG_IMAGE_REV"
+
 
 if [ "$CHANNEL" != unpublished ]; then
     charm release "$URL" --channel "$CHANNEL" --resource "$NADF-image-$NADF_IMAGE_REV" --resource "multus-image-$MULTUS_IMAGE_REV"

--- a/src/charm.py
+++ b/src/charm.py
@@ -77,6 +77,13 @@ class MultusCharm(CharmBase):
         for net_attach_def in net_attach_defs:
             net_attach_def['metadata'].setdefault('namespace', self.model.name)
 
+        kube_multus_args = [
+            '--multus-conf-file=auto',
+            '--cni-version=0.3.1'
+        ]
+        if self.model.config.get('debug'):
+            kube_multus_args.append('--multus-log-level=debug')
+
         self.model.unit.status = MaintenanceStatus('Setting pod spec')
         pod_spec = {
             'version': 3,
@@ -85,10 +92,7 @@ class MultusCharm(CharmBase):
                     'name': 'kube-multus',
                     'imageDetails': multus_image_details,
                     'command': ['/entrypoint.sh'],
-                    'args': [
-                        '--multus-conf-file=auto',
-                        '--cni-version=0.3.1'
-                    ],
+                    'args': kube_multus_args,
                     'volumeConfig': [
                         {
                             'name': 'cni',

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,6 +15,7 @@ class MultusCharm(CharmBase):
     def __init__(self, framework, key):
         super().__init__(framework, key)
         self.multus_image = OCIImageResource(self, 'multus-image')
+        self.multus_dbg_image = OCIImageResource(self, 'multus-debug-image')
         self.nadm_image = OCIImageResource(self,
                                            'net-attach-def-manager-image')
         self.framework.observe(self.on.install, self.set_pod_spec)
@@ -28,7 +29,11 @@ class MultusCharm(CharmBase):
             return
 
         try:
-            multus_image_details = self.multus_image.fetch()
+            multus_image_details = None
+            if self.model.config.get('debug'):
+                multus_image_details = self.multus_dbg_image.fetch()
+            else:
+                multus_image_details = self.multus_image.fetch()
             nadm_image_details = self.nadm_image.fetch()
         except OCIImageResourceError as e:
             self.model.unit.status = e.status


### PR DESCRIPTION
Adding the following to multus charm:
* move multus image to Ubuntu as base instead of centos
* debug option: set LogLevel to debug
* multus-debug image which ships multus with delve debugger

