### PR TITLE
Change net-attach-def crd based on apiextensions.k8s.io/v1 API spec

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -161,23 +161,32 @@ class MultusCharm(CharmBase):
                         'versions': [{
                             'name': 'v1',
                             'served': True,
-                            'storage': True
-                        }],
-                        'validation': {
-                            'openAPIV3Schema': {
-                                'type': 'object',
-                                'properties': {
-                                    'spec': {
-                                        'type': 'object',
-                                        'properties': {
-                                            'config': {
-                                                'type': 'string'
+                            'storage': True,
+                            'schema': {
+                                'openAPIV3Schema': {
+                                    'type': 'object',
+                                    'properties': {
+                                        'apiVersion': {
+                                            'type': 'string'
+                                        },
+                                        'kind': {
+                                            'type': 'string'
+                                        },
+                                        'metadata': {
+                                            'type': 'object'
+                                        },
+                                        'spec': {
+                                            'type': 'object',
+                                            'properties': {
+                                                'config': {
+                                                    'type': 'string'
+                                                }
                                             }
                                         }
                                     }
                                 }
                             }
-                        }
+                        }],
                     }
                 }]
             }


### PR DESCRIPTION
CRD spec apiextensions.k8s.io/v1beta1 is removed from v1.22.
Modify the network-attachment-definition CRD based on
apiextensions.k8s.io/v1

[1] https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122

Closes-Bug: #1957032