### PR TITLE
Add charmcraft.yaml

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,4 @@
+type: charm
+bases:
+- name: ubuntu
+  channel: "20.04"


### PR DESCRIPTION
As of Charmcraft 1.5.0, this charm fails to build:

```
$ charmcraft pack
The specified command needs a valid 'charmcraft.yaml' configuration file (in the current directory or where specified with --project-dir option); see the reference: https://discourse.charmhub.io/t/charmcraft-configuration/4138
```

Add a basic charmcraft.yaml to get this building.