### PR TITLE
Update image-registry default to ghcr.io/canonical/cdk

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -27,7 +27,7 @@ jobs:
           charmcraft-channel: ${{ steps.charmcraft.outputs.channel }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
-          bootstrap-options: "${{ secrets.NOBLE_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763 --config caas-image-repo=rocks.canonical.com/cdk/jujusolutions"
+          bootstrap-options: "${{ secrets.NOBLE_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763 --config caas-image-repo=ghcr.io/canonical/cdk/jujusolutions"
       - name: Run test
         run: tox -e integration -- ${EXTRA_ARGS}
       - name: Setup Debug Artifact Collection

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -52,7 +52,7 @@ bases:
 config:
   options:
     image-registry:
-      default: rocks.canonical.com:443/cdk
+      default: ghcr.io/canonical/cdk
       type: string
       description: |
         Source registry of Multus CNI images.

--- a/src/net_attach_definitions.py
+++ b/src/net_attach_definitions.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 """Module for managing Network Attachment Definitions"""
+
 import logging
 import traceback
 from typing import List, Set


### PR DESCRIPTION
`rocks.canonical.com` is being retired. This PR updates the image registry
references from the legacy registry to the new GitHub Container Registry.

**Changes:**
- `rocks.canonical.com:443/cdk` → `ghcr.io/canonical/cdk`
- `rocks.canonical.com/cdk` → `ghcr.io/canonical/cdk`
