### PR TITLE
Apply black formatting to net_attach_definitions.py

### DIFF
--- a/src/net_attach_definitions.py
+++ b/src/net_attach_definitions.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 """Module for managing Network Attachment Definitions"""
+
 import logging
 import traceback
 from typing import List, Set


### PR DESCRIPTION
CI is failing on all PRs due to a pre-existing black formatting issue in `src/net_attach_definitions.py`.

This PR applies `black` formatting to fix the lint check.

```
black src/net_attach_definitions.py
```